### PR TITLE
Add cross-platform support for parsing .daprc

### DIFF
--- a/davtk/dap.py
+++ b/davtk/dap.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os, re, threading, queue
 import vtk
+from pathlib import Path
 from davtk.settings import DavTKSettings
 from davtk.parse import parse_file
 from davtk.state import *
@@ -12,7 +13,7 @@ class Viewer(object):
         # read settings from home dir and current dir
         settings = DavTKSettings()
         try:
-            parse_file(os.path.join(os.environ["HOME"],".daprc"), settings=settings)
+            parse_file(os.path.join(Path.home(),".daprc"), settings=settings)
         except IOError:
             pass
         try:


### PR DESCRIPTION
Usage of Path.home() from pathlib (requires Python 3.4+) enables cross-platform support for Windows, Mac, Linux when parsing .daprc