### PR TITLE
Usage and help message full text search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_namespace_packages
 import os, glob
 
 setup(name='dap',
-      version='0.9.3',
+      version='0.9.4',
       description='Display atomic configuration',
       author='Noam Bernstein',
-      author_email='noam.bernstein@nrl.navy.mil',
+      author_email='noam.bernstein.civ@us.navy.mil',
       packages=find_namespace_packages(where="src"),
       package_dir={"": "src"},
       package_data={'davtk.scripts': ['*'], 'davtk.examples': ['*']},

--- a/src/davtk/settings.py
+++ b/src/davtk/settings.py
@@ -101,7 +101,7 @@ class DavTKSettings():
     parsers = {}
 
     _parser_atom_type_field = ThrowingArgumentParser(prog="atom_type_field", description="ASE at.arrays field to use for atom type")
-    _parser_atom_type_field.add_argument("field", help="name of field ('Z' for atomic numbers, 'species' for chemical symbols", default='Z')
+    _parser_atom_type_field.add_argument("field", help="name of field ('Z' for atomic numbers, 'species' for chemical symbols)", default='Z')
     parsers["atom_type_field"] = _parser_atom_type_field
 
     _parser_print_settings = ThrowingArgumentParser(prog="print_settings", description="print settings")
@@ -142,17 +142,17 @@ class DavTKSettings():
     parsers["atom_type"] = _parser_atom_type
 
     _parser_cell_box = ThrowingArgumentParser(prog="cell_box")
-    _parser_cell_box.add_argument("-color", nargs=3, type=float, metavar=['R', 'G', 'B'], default=None)
+    _parser_cell_box.add_argument("-color", nargs=3, type=float, metavar=('R', 'G', 'B'), default=None)
     _parser_cell_box.add_argument("-opacity", type=float, default=None)
     _parser_cell_box.add_argument("-width", type=float, default=None)
     parsers["cell_box"] = _parser_cell_box
 
     _parser_picked = ThrowingArgumentParser(prog="picked")
-    _parser_picked.add_argument("-color", nargs=3, type=float, metavar=['R', 'G', 'B'])
+    _parser_picked.add_argument("-color", nargs=3, type=float, metavar=('R', 'G', 'B'))
     parsers["picked"] = _parser_picked
 
     _parser_background_color = ThrowingArgumentParser(prog="background_color")
-    _parser_background_color.add_argument("-color", nargs=3, type=float, metavar=['R', 'G', 'B'])
+    _parser_background_color.add_argument("-color", nargs=3, type=float, metavar=('R', 'G', 'B'))
     parsers["background_color"] = _parser_background_color
 
     _parser_frame_label = ThrowingArgumentParser(prog="frame_label")

--- a/src/davtk/viewer.py
+++ b/src/davtk/viewer.py
@@ -312,9 +312,9 @@ class Viewer(object):
         Parameters
         ----------
         full_text: bool, default False
-            search for glob in full text of help message
+            search for glob in full text of usage message
         glob: str, default "*"
-            shell-styl glob to match for keywords to print usage for
+            shell-style glob to match for keywords to print usage for
 
         Returns
         -------
@@ -322,6 +322,7 @@ class Viewer(object):
         """
         regexp = re.sub(r"\?", ".", glob)
         regexp = re.sub(r"\*", ".*", regexp)
+        regexp = "^" + regexp + "$"
 
         for parsers, label in [(self.davtk_state.settings.parsers, "SETTINGS"),
                                (self.parsers, "COMMANDS")]:
@@ -354,6 +355,7 @@ class Viewer(object):
         """
         regexp = re.sub(r"\?", ".", glob)
         regexp = re.sub(r"\*", ".*", regexp)
+        regexp = "^" + regexp + "$"
 
         for parsers in (self.davtk_state.settings.parsers, self.parsers):
             for keyword in [k for k in sorted(parsers.keys()) if
@@ -542,7 +544,7 @@ class Viewer(object):
         -------
         refresh: None
         """
-        m = re.search("^(\d*)(?::(\d*)(?::(\d*))?)?$", frame_range)
+        m = re.search(r"^(\d*)(?::(\d*)(?::(\d*))?)?$", frame_range)
         if not m:
             raise SyntaxError("range '{}' is not in the expected format".format(frame_range))
         range_start = 0 if m.group(1) is None or len(m.group(1)) == 0 else int(m.group(1))

--- a/src/davtk/viewer.py
+++ b/src/davtk/viewer.py
@@ -313,8 +313,8 @@ class Viewer(object):
         ----------
         full_text: bool, default False
             search for glob in full text of help message
-        glob: str, default "."
-            glob to match for keywords to print usage for
+        glob: str, default "*"
+            shell-styl glob to match for keywords to print usage for
 
         Returns
         -------
@@ -345,8 +345,8 @@ class Viewer(object):
         ----------
         full_text: bool, default False
             search for glob in full text of help message
-        glob: str, default "."
-            glob to match for keywords to print usage for
+        glob: str, default "*"
+            shell-style glob to match for keywords to print usage for
 
         Returns
         -------

--- a/src/davtk/viewer.py
+++ b/src/davtk/viewer.py
@@ -322,7 +322,8 @@ class Viewer(object):
         """
         regexp = re.sub(r"\?", ".", glob)
         regexp = re.sub(r"\*", ".*", regexp)
-        regexp = "^" + regexp + "$"
+        if not full_text:
+            regexp = "^" + regexp + "$"
 
         for parsers, label in [(self.davtk_state.settings.parsers, "SETTINGS"),
                                (self.parsers, "COMMANDS")]:
@@ -355,7 +356,8 @@ class Viewer(object):
         """
         regexp = re.sub(r"\?", ".", glob)
         regexp = re.sub(r"\*", ".*", regexp)
-        regexp = "^" + regexp + "$"
+        if not full_text:
+            regexp = "^" + regexp + "$"
 
         for parsers in (self.davtk_state.settings.parsers, self.parsers):
             for keyword in [k for k in sorted(parsers.keys()) if

--- a/src/davtk/viewer.py
+++ b/src/davtk/viewer.py
@@ -361,7 +361,7 @@ class Viewer(object):
                              re.match(regexp, k) or
                              (full_text and re.search(regexp, parsers[k].format_help(), re.MULTILINE)))]:
                 print("--------------------------------------------------------------------------------")
-                print(keyword, self.davtk_state.settings.parsers[keyword].format_help(), end='')
+                print(keyword, parsers[keyword].format_help(), end='')
 
         return None
 


### PR DESCRIPTION
enable full-text search in `usage` and `help` commands.  Switch to shell-style glob from regexp.